### PR TITLE
Finally fix card announcement animation in Safari.

### DIFF
--- a/both/gamestate.js
+++ b/both/gamestate.js
@@ -26,7 +26,7 @@ GameState = {
 (function (scope) {
   var _NEXT_PHASE_DELAY = 250;
   var _ANNOUNCE_NEXT_PHASE = 1000;
-  var _ANNOUNCE_CARD_TIME = 1000;
+  var _ANNOUNCE_CARD_TIME = 1750; // match to .fadeInAndOut duration in style.sass
   var _EXECUTE_CARD_TIME = 1000;
 
   // game phases:

--- a/client/stylesheets/modules/card.sass
+++ b/client/stylesheets/modules/card.sass
@@ -52,8 +52,9 @@ $card-height: 153/99
 
   &.announce-move
     position: absolute
-    width: 2px
-    height: $card-height*2px
+    /* change cardPlaying() position offset in board.js */
+    width: 100px
+    height: $card-height*100px
     padding: 0
 
   &.covered

--- a/client/stylesheets/style.sass
+++ b/client/stylesheets/style.sass
@@ -238,14 +238,21 @@ h5.player-status
 
 @keyframes fadeInAndOut
   0%, 50%, 100%
-    transition-timing-function: cubic-bezier(0, 1, 1, 0)
+    transition-timing-function: cubic-bezier(0.1, 0.5, 1, 0)
 
   0%
     transform: scale(0, 0)
-  50%
-    transform: scale(50, 50)
+    opacity: 1
+  30%
+    transform: scale(0.7, 0.7)
+    opacity: 1
   100%
-    transform: scale(100, 100)
+    transform: scale(1.2, 1.2)
+    opacity: 0
+
 
 .fadeInAndOut
-  animation: fadeInAndOut 1.75s both
+  animation-name: fadeInAndOut
+  animation-duration: 1.75s /* match to _ANNOUNCE_CARD_TIME in gamestate.js */
+  animation-fill-mode: both
+  animation-iteration-count: 1

--- a/client/views/board/board.js
+++ b/client/views/board/board.js
@@ -240,7 +240,8 @@ Template.board.helpers({
       priority: CardLogic.priority(cardId),
       type: CardLogic.cardType(cardId, game.playerCnt()).name,
       playerName: player.name,
-      position: cssPosition(player.position.x, player.position.y, 25, 25),
+      // offsets based on the size of &.announce-move in card.sass...
+      position: cssPosition(player.position.x, player.position.y, -25, -50),
       robotId: player.robotId.toString()
     };
 


### PR DESCRIPTION
Safari doesn't scale the background-image on the card announcement while it's being animated and simply scales the background-image as it exists prior to animation.  For a 2x3px image there's not a lot to scale and you see a black box instead of the card.  Clearly, Chrome handles this differently.  Starting with the card at full-size card and animating it from scale(0, 0) solves this issue for Safari and maintains the same visual effect.